### PR TITLE
Updated support item purchases

### DIFF
--- a/hero_selection.lua
+++ b/hero_selection.lua
@@ -13,7 +13,7 @@ function Think()
 		print( "game mode: ", a);
 
 		if ( a == GAMEMODE_AP )
-		then 
+		then
 			print ( "All Pick" )
 			if ( GetTeam() == TEAM_RADIANT )
 			then
@@ -22,7 +22,7 @@ function Think()
 				SelectHero( 3, "npc_dota_hero_viper" );
 				SelectHero( 4, "npc_dota_hero_bloodseeker" );
 				SelectHero( 5, "npc_dota_hero_lina" );
-				SelectHero( 6, "npc_dota_hero_crystal_maiden" );
+				SelectHero( 6, "npc_dota_hero_antimage" );
 			elseif ( GetTeam() == TEAM_DIRE )
 			then
 				print( "selecting dire" );

--- a/item_purchase_drow_ranger.lua
+++ b/item_purchase_drow_ranger.lua
@@ -19,14 +19,14 @@ local tableItemsToBuyAsJungler = {
 	"item_boots_of_elves",
 	"item_recipe_power_treads", -- completes Power Treads
 	"item_boots_of_elves",
-	"item_boots_of_elves", 
+	"item_boots_of_elves",
 	"item_lifesteal",  -- get lifesteal
 	"item_ogre_axe", -- completes Dragon Lance
 	"item_gloves",
-	"item_mithril_hammer", 
+	"item_mithril_hammer",
 	"item_recipe_maelstrom", -- completes Maelstrom
-	"item_ring_of_regen", 
-	"item_staff_of_wizardry", 
+	"item_ring_of_regen",
+	"item_staff_of_wizardry",
 	"item_recipe_force_staff",
 	"item_recipe_hurricane_pike", -- completes Hurricane Pike
 	"item_blade_of_alacrity",
@@ -40,7 +40,7 @@ local tableItemsToBuyAsJungler = {
 	"item_eagle",
 	"item_talisman_of_evasion",
 	"item_quarterstaff", -- completes Butterfly
-	"item_reaver", 
+	"item_reaver",
 	"item_mithril_hammer" -- completes Satanic
 };
 
@@ -63,17 +63,17 @@ local tableItemsToBuyAsHardCarry = {
 	"item_boots_of_elves",
 	"item_recipe_power_treads", -- completes Power Treads
 	"item_boots_of_elves",
-	"item_boots_of_elves", 
+	"item_boots_of_elves",
 	"item_ogre_axe", -- completes Dragon Lance
 	"item_gloves",
-	"item_mithril_hammer", 
+	"item_mithril_hammer",
 	"item_recipe_maelstrom", -- completes Maelstrom
-	"item_ring_of_regen", 
-	"item_staff_of_wizardry", 
+	"item_ring_of_regen",
+	"item_staff_of_wizardry",
 	"item_recipe_force_staff",
 	"item_recipe_hurricane_pike", -- completes Hurrican Pike
 	"item_point_booster",
-	"item_blade_of_alacrity", 
+	"item_blade_of_alacrity",
 	"item_ogre_axe",
 	"item_staff_of_wizardry",  -- completes Aghanim's Scepter
 	"item_hyperstone",
@@ -81,10 +81,10 @@ local tableItemsToBuyAsHardCarry = {
 	"item_eagle",
 	"item_talisman_of_evasion",
 	"item_quarterstaff", -- completes Butterfly
-	"item_broadsword", 
-	"item_blades_of_attack", 
+	"item_broadsword",
+	"item_blades_of_attack",
 	"item_recipe_lesser_crit", -- completes Crystalys
-	"item_demon_edge",  
+	"item_demon_edge",
 	"item_recipe_greater_crit" -- completes Daedalus
 }
 
@@ -92,6 +92,42 @@ local tableItemsToBuyAsOfflane = {
 }
 
 local tableItemsToBuyAsMid = {
+	"item_slippers",
+	"item_circlet",
+	"item_tango",
+	"item_branches",
+	"item_branches",
+	"item_recipe_wraith_band",
+	"item_boots",
+	"item_ring_of_protection",
+	"item_sobi_mask", -- completes Ring of Aquila
+	"item_gloves",
+	"item_boots_of_elves",
+	"item_recipe_power_treads", -- completes Power Treads
+	"item_boots_of_elves",
+	"item_boots_of_elves",
+	"item_ogre_axe", -- completes Dragon Lance
+	"item_gloves",
+	"item_mithril_hammer",
+	"item_recipe_maelstrom", -- completes Maelstrom
+	"item_ring_of_regen",
+	"item_staff_of_wizardry",
+	"item_recipe_force_staff",
+	"item_recipe_hurricane_pike", -- completes Hurrican Pike
+	"item_point_booster",
+	"item_blade_of_alacrity",
+	"item_ogre_axe",
+	"item_staff_of_wizardry",  -- completes Aghanim's Scepter
+	"item_hyperstone",
+	"item_recipe_mjollnir", -- commpletes Mjollnir
+	"item_eagle",
+	"item_talisman_of_evasion",
+	"item_quarterstaff", -- completes Butterfly
+	"item_broadsword",
+	"item_blades_of_attack",
+	"item_recipe_lesser_crit", -- completes Crystalys
+	"item_demon_edge",
+	"item_recipe_greater_crit" -- completes Daedalus
 }
 
 local tableItemsToBuyAsSupport = {

--- a/item_purchase_lina.lua
+++ b/item_purchase_lina.lua
@@ -1,106 +1,141 @@
 -------------------------------------------------------------------------------
---- AUTHOR: Nostrademous
+--- AUTHOR: Nostrademous, dralois
 --- GITHUB REPO: https://github.com/Nostrademous/Dota2-FullOverwrite
 -------------------------------------------------------------------------------
 
-require( GetScriptDirectory().."/generic_item_purchase" )
+local item_purchase = require( GetScriptDirectory().."/item_purchase_generic_test" )
 
-local tableItemsToBuyAsSupport = { 
-	"item_tango",
-	"item_tango",
-	"item_clarity",
-	"item_clarity",
-	"item_branches",
-	"item_branches",
-	"item_magic_stick",
-	"item_circlet",
-	"item_boots",
-	"item_energy_booster",
-	"item_staff_of_wizardry",
-	"item_ring_of_regen",
-	"item_recipe_force_staff",
-	"item_point_booster",
-	"item_staff_of_wizardry",
-	"item_ogre_axe",
-	"item_blade_of_alacrity",
-	"item_mystic_staff",
-	"item_ultimate_orb",
-	"item_void_stone",
-	"item_staff_of_wizardry",
-	"item_wind_lace",
-	"item_void_stone",
-	"item_recipe_cyclone",
-	"item_cyclone",
+----------------------------------------------------------------------------------------------------
+
+local ItemsToBuyAsHardCarry = {
+	StartingItems = {
+		"item_null_talisman",
+		"item_faerie_fire",
+		"item_branches",
+		"item_bottle"
+	},
+	UtilityItems = {
+		"item_flask"
+	},
+	CoreItems = {
+		"item_phase_boots",
+		"item_cyclone",
+		"item_blink",
+		"item_aether_lens",
+		"item_ultimate_scepter"
+	},
+	ExtensionItems = {
+		{
+		},
+		{
+		}
+	}
+}
+local ItemsToBuyAsMid = {
+	StartingItems = {
+		"item_null_talisman",
+		"item_faerie_fire",
+		"item_branches",
+		"item_bottle"
+	},
+	UtilityItems = {
+		"item_flask"
+	},
+	CoreItems = {
+		"item_phase_boots",
+		"item_cyclone",
+		"item_blink",
+		"item_aether_lens",
+		"item_ultimate_scepter"
+	},
+	ExtensionItems = {
+		{
+		},
+		{
+		}
+	}
+}
+local ItemsToBuyAsOfflane = {}
+local ItemsToBuyAsSupport = {
+	StartingItems = {
+		"item_tango",
+		"item_tango",
+		"item_clarity",
+		"item_clarity",
+		"item_branches",
+		"item_branches"
+	},
+	UtilityItems = {
+		"item_flask"
+	},
+	CoreItems = {
+		"item_magic_wand",
+		"item_arcane_boots",
+		"item_cyclone",
+		"item_force_staff",
+		"item_ultimate_scepter",
+		"item_sheepstick"
+	},
+	ExtensionItems = {
+		{
+		},
+		{
+		}
+	}
+}
+local ItemsToBuyAsJungler = {}
+local ItemsToBuyAsRoamer = {}
+
+ToBuy = item_purchase:new()
+
+-- create a 2nd layer of isolation so this bot has it's own instance not shared with other bots
+function ToBuy:new(o)
+	o = o or item_purchase:new(o)
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+-- we need these so if multiple bots inherit from the generic class they don't get mixed with each other
+local myPurchaseOrder = {}
+local myBoughtItems = {}
+local myStartingItems = {}
+local myUtilityItems = {}
+local myCoreItems = {}
+local myExtensionItems = {
+	OffensiveItems = {},
+	DefensiveItems = {}
 }
 
-local tableItemsToBuyAsMid = { 
-	"item_circlet",
-	"item_mantle",
-	"item_recipe_null_talisman",
-	"item_faerie_fire",
-	"item_branches",
-	"item_bottle",
-	"item_boots",
-	"item_wind_lace",
-	"item_blades_of_attack",
-	"item_blades_of_attack",
-	"item_staff_of_wizardry",
-	"item_void_stone",
-	"item_recipe_cyclone",
-	"item_cyclone",
-	"item_blink",
-	"item_energy_booster",
-	"item_ring_of_health",
-	"item_recipe_aether_lens",
-	"item_aether_lens",
-	"item_point_booster",
-	"item_ogre_axe",
-	"item_staff_of_wizardry",
-	"item_blade_of_alacrity",
-	"item_ultimate_orb",
-	"item_ultimate_orb",
-}
-			
-local tableItemsToBuyAsHardCarry = { 
-	"item_circlet",
-	"item_mantle",
-	"item_recipe_null_talisman",
-	"item_faerie_fire",
-	"item_branches",
-	"item_boots",
-	"item_blades_of_attack",
-	"item_blades_of_attack",
-	"item_wind_lace",
-	"item_staff_of_wizardry",
-	"item_void_stone",
-	"item_recipe_cyclone",
-	"item_cyclone",
-	"item_blink",
-	"item_energy_booster",
-	"item_ring_of_health",
-	"item_recipe_aether_lens",
-	"item_aether_lens",
-	"item_point_booster",
-	"item_ogre_axe",
-	"item_staff_of_wizardry",
-	"item_blade_of_alacrity",
-	"item_ultimate_orb",
-	"item_ultimate_orb",
-}
+local init = false
 
-local tableItemsToBuyAsOfflane = {
-}
+linaBuy = ToBuy:new()
+-- set our members to our localized values so we don't fall through to parent's class members
+linaBuy.PurchaseOrder = myPurchaseOrder
+linaBuy.BoughtItems = myBoughtItems
+linaBuy.StartingItems = myStartingItems
+linaBuy.UtilityItems = myUtilityItems
+linaBuy.CoreItems = myCoreItems
+linaBuy.ExtensionItems = myExtensionItems
 
-local tableItemsToBuyAsJungler = {
-}
-
-local tableItemsToBuyAsRoamer = {
-}
+linaBuy.ItemsToBuyAsHardCarry = ItemsToBuyAsHardCarry
+linaBuy.ItemsToBuyAsMid = ItemsToBuyAsMid
+linaBuy.ItemsToBuyAsOfflane = ItemsToBuyAsOfflane
+linaBuy.ItemsToBuyAsSupport = ItemsToBuyAsSupport
+linaBuy.ItemsToBuyAsJungler = ItemsToBuyAsJungler
+linaBuy.ItemsToBuyAsRoamer = ItemsToBuyAsRoamer
 
 ----------------------------------------------------------------------------------------------------
 
 function ItemPurchaseThink()
-	generic_item_purchase.ItemPurchaseThink(tableItemsToBuyAsMid, tableItemsToBuyAsHardCarry, tableItemsToBuyAsOfflane, tableItemsToBuyAsSupport, tableItemsToBuyAsJungler, tableItemsToBuyAsRoamer)
+	local npcBot = GetBot()
+
+	if not init then
+			-- init the tables
+			init = linaBuy:InitTable()
+	end
+
+	linaBuy:Think(npcBot)
 end
 
 ----------------------------------------------------------------------------------------------------

--- a/item_purchase_viper.lua
+++ b/item_purchase_viper.lua
@@ -3,10 +3,6 @@
 --- GITHUB REPO: https://github.com/Nostrademous/Dota2-FullOverwrite
 -------------------------------------------------------------------------------
 
---[[
-require( GetScriptDirectory().."/generic_item_purchase" )
---]]
-
 local item_purchase = require( GetScriptDirectory().."/item_purchase_generic_test" )
 
 ----------------------------------------------------------------------------------------------------
@@ -15,7 +11,7 @@ local ItemsToBuyAsHardCarry = {
 	StartingItems = {
 		"item_stout_shield",
 		"item_flask",
-		"item_faerie_fire",
+		"item_faerie_fire"
 	},
 	UtilityItems = {
 		"item_flask"
@@ -40,7 +36,7 @@ local ItemsToBuyAsMid = {
 	StartingItems = {
 		"item_stout_shield",
 		"item_flask",
-		"item_faerie_fire",
+		"item_faerie_fire"
 	},
 	UtilityItems = {
 		"item_flask"
@@ -66,7 +62,7 @@ local ItemsToBuyAsOfflane = {
 		"item_ward_observer",
 		"item_stout_shield",
 		"item_flask",
-		"item_faerie_fire",
+		"item_faerie_fire"
 	},
 	UtilityItems = {
 		"item_flask"
@@ -80,10 +76,13 @@ local ItemsToBuyAsOfflane = {
 	ExtensionItems = {
 		{
 			"item_ultimate_scepter",
+			"item_butterfly",
 			"item_assault"
 		},
 		{
-			"item_heart"
+			"item_pipe",
+			"item_heart",
+			"item_manta"
 		}
 	}
 }

--- a/role.lua
+++ b/role.lua
@@ -64,7 +64,7 @@ local listHC = {
 	"npc_dota_hero_weaver",
 	--"npc_dota_hero_windrunner",
 };
-	
+
 local listMID = {
 --comments by "ByBurton":	I define Mid as Semicarries. Heroes that need exp and some gold early on, that can easily win lanes 1 vs 1 through skill spamming or harrassing - position 2; always in mid.
 --Have skills that scale bad in early and good into lategame - mostly physical dmg.
@@ -117,7 +117,7 @@ local listMID = {
 	"npc_dota_hero_windrunner",
 	"npc_dota_hero_zuus",
 };
-	
+
 local listOFF = {
 --comments by "ByBurton":	I define Offlaner as Semicarries too, but a bit less gold focused. They need mostly exp early on, and they play defensiv / use defensive skills to survive their lane 1 vs 2-3 - position 3;
 --always solo or with another support; in offlane aka hardlane. Have abilities that scale good in midgame.
@@ -210,7 +210,7 @@ local listJUNGLER = {
 	"npc_dota_hero_lifestealer",
 	--"npc_dota_hero_lycan",
 };
-	
+
 local listSEMISUPPORT = {
 --comments by "ByBurton":	I define semi supports as supports who need a little money. they usually do not buy the wards and smokes. Usually have supporting abilities. They help in ganks, and buy other utility items. Require some more
 --gold / exp than full supports - Position 4 - usually helping the offlaner or in a trilane with the safelane carry.
@@ -230,7 +230,7 @@ local listSEMISUPPORT = {
 	"npc_dota_hero_jakiro",
 	"npc_dota_hero_leshrac",			--not sure here
 	"npc_dota_hero_lich",
-	--"npc_dota_hero_lina",	-- not really a good support
+	"npc_dota_hero_lina",	-- not really a good support
 	"npc_dota_hero_lion",
 	"npc_dota_hero_ogre_magi",
 	"npc_dota_hero_omniknight",
@@ -285,7 +285,7 @@ local listHARDSUPPORT = {
 	"npc_dota_hero_winter_wyvern",
 	"npc_dota_hero_wisp",
 };
-	
+
 ----------------------------------------------------------------------------------------------------
 
 local function contains(table, value)
@@ -402,14 +402,14 @@ local best = nil
 local function fillRoles(rMatrix)
 	obj = everyObjectAssigned(rMatrix)
 
-	if obj ~= 0 then	
+	if obj ~= 0 then
 		local slot = GetTeamMember( GetTeam(), obj )
 		validRoles = findRole(slot:GetUnitName())
 		for k,v in pairs (validRoles) do
 			if #v > 0 then
 				new = utils.deepcopy(rMatrix)
 				table.insert(new[k], slot:GetUnitName())
-				
+
 				new = fillRoles(new)
 				if everyObjectAssigned(new) == 0 and best == nil then
 					best = utils.deepcopy(new)
@@ -423,7 +423,7 @@ local function fillRoles(rMatrix)
 				end
 			end
 		end
-		
+
 	end
 	return rMatrix
 end
@@ -457,14 +457,14 @@ function GetRoles()
 	if ( not RolesFilled() ) then
 		SetRoles()
 	end
-	
+
 	return roles;
 end
 
 function GetLaneAndRole(team, role_indx)
 	local r = GetRoles()
 	local rl = roles[role_indx]
-	
+
 	if rl == ROLE_MID then
 		return LANE_MID, rl
 	elseif rl == ROLE_OFFLANE then


### PR DESCRIPTION
Support items are now considered every 10s no matter what, they are put on the purchase table in front of everything else if available. Supports buy wards, couriers (and the upgrade) and tomes (that are not being used as of right now). Also made lina a support and made her use the new purchase version. Added mid build for drow (was causing problems).