### PR TITLE
[Issue #103] Smart Glyph Use

### DIFF
--- a/buildings_status.lua
+++ b/buildings_status.lua
@@ -108,6 +108,16 @@ function GetStandingTowerIDs(team)
     return ids
 end
 
+function GetDestroyableTowers(team)
+    ids = {}
+    for i, building in pairs(tableBuildings[team]) do
+        if GetTowerHealth(team, i) > -1 and (not building:IsInvulnerable()) then
+            ids[#ids+1] = i
+        end
+	end
+    return ids
+end
+
 function printBuildings()
     print("Buildings Radiant")
     for i, building in pairs(tableBuildings[TEAM_RADIANT]) do

--- a/buildings_status.lua
+++ b/buildings_status.lua
@@ -114,7 +114,7 @@ function GetDestroyableTowers(team)
         if GetTowerHealth(team, i) > -1 and (not building:IsInvulnerable()) then
             ids[#ids+1] = i
         end
-	end
+    end
     return ids
 end
 

--- a/decision_tree.lua
+++ b/decision_tree.lua
@@ -427,6 +427,17 @@ function X:ConsiderItemUse()
 end
 
 function X:Determine_ShouldUseGlyph(bot)
+    local vulnerableTowers = buildings_status.GetDestroyableTowers(GetTeam())
+	for i, building_id in pairs(vulnerableTowers) do
+	    local tower = buildings_status.GetTowerUnit(GetTeam(), building_id)
+		local nearbyEnemyCreepCount = tower:GetNearbyCreeps(tower:getAttackRange(), true)
+		local nearbyHeroCount = tower:GetNearbyHeroes(tower:getAttackRange(), true, BOT_MODE_NONE);
+		
+		if tower:GetHealth()/tower:GetMaxHealth() < math.max(tower:GetMaxHealth()*0.15, 150) and tower:TimeSinceDamagedByAnyHero() < 3
+		and tower:TimeSinceDamagedByCreep() < 3 and nearbyEnemyCreepCount >= 2 and nearbyHeroCount >= 1 then
+		    return true
+		end
+    end
     return false
 end
 

--- a/decision_tree.lua
+++ b/decision_tree.lua
@@ -428,12 +428,12 @@ end
 
 function X:Determine_ShouldUseGlyph(bot)
     local vulnerableTowers = buildings_status.GetDestroyableTowers(GetTeam())
-	for i, building_id in pairs(vulnerableTowers) do
+    for i, building_id in pairs(vulnerableTowers) do
 	    local tower = buildings_status.GetTowerUnit(GetTeam(), building_id)
 	    local nearbyEnemyCreepCount = tower:GetNearbyCreeps(tower:getAttackRange(), true)
 	    local nearbyHeroCount = tower:GetNearbyHeroes(tower:getAttackRange(), true, BOT_MODE_NONE);
 		
-	    if tower:GetHealth()/tower:GetMaxHealth() < math.max(tower:GetMaxHealth()*0.15, 150) and tower:TimeSinceDamagedByAnyHero() < 3
+	    if tower:GetHealth() < math.max(tower:GetMaxHealth()*0.15, 150) and tower:TimeSinceDamagedByAnyHero() < 3
 	    and tower:TimeSinceDamagedByCreep() < 3 and nearbyEnemyCreepCount >= 2 and nearbyHeroCount >= 1 then
 		    return true
 	    end

--- a/decision_tree.lua
+++ b/decision_tree.lua
@@ -430,13 +430,13 @@ function X:Determine_ShouldUseGlyph(bot)
     local vulnerableTowers = buildings_status.GetDestroyableTowers(GetTeam())
 	for i, building_id in pairs(vulnerableTowers) do
 	    local tower = buildings_status.GetTowerUnit(GetTeam(), building_id)
-		local nearbyEnemyCreepCount = tower:GetNearbyCreeps(tower:getAttackRange(), true)
-		local nearbyHeroCount = tower:GetNearbyHeroes(tower:getAttackRange(), true, BOT_MODE_NONE);
+	    local nearbyEnemyCreepCount = tower:GetNearbyCreeps(tower:getAttackRange(), true)
+	    local nearbyHeroCount = tower:GetNearbyHeroes(tower:getAttackRange(), true, BOT_MODE_NONE);
 		
-		if tower:GetHealth()/tower:GetMaxHealth() < math.max(tower:GetMaxHealth()*0.15, 150) and tower:TimeSinceDamagedByAnyHero() < 3
-		and tower:TimeSinceDamagedByCreep() < 3 and nearbyEnemyCreepCount >= 2 and nearbyHeroCount >= 1 then
+	    if tower:GetHealth()/tower:GetMaxHealth() < math.max(tower:GetMaxHealth()*0.15, 150) and tower:TimeSinceDamagedByAnyHero() < 3
+	    and tower:TimeSinceDamagedByCreep() < 3 and nearbyEnemyCreepCount >= 2 and nearbyHeroCount >= 1 then
 		    return true
-		end
+	    end
     end
     return false
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1123,7 +1123,7 @@ function U.IsHeroAttackingMe(hero, fTime)
     local fTime = fTime or 2.0
     local npcBot = GetBot()
 
-    if npcBot:WasRecentlyDamagedByAnyHero(hero, fTime) then
+    if npcBot:WasRecentlyDamagedByHero(hero, fTime) then
         return true
     end
     return false


### PR DESCRIPTION
- implemented tower checking for glyph use
- takes into account nearby enemy hero count and nearby creep count as
well as last time damage by both enemy hero and creep
- fixed a function in decition_tree.lua

Question: Should I take into account the number of allied hero near the tower before activating glyph?