### PR TITLE
Various improvement

### DIFF
--- a/item_purchase_drow_ranger.lua
+++ b/item_purchase_drow_ranger.lua
@@ -22,8 +22,10 @@ local ItemsToBuyAsHardCarry = {StartingItems = {
 		"item_power_treads_agi",
 		"item_dragon_lance",
 		"item_maelstrom",
-		"item_aghs_scepter",
-		"item_mjollnir"
+		"item_ultimate_scepter",
+		"item_mjollnir",
+		"item_lesser_crit",
+		"item_greater_crit"
 	},
 	ExtensionItems = {
 		OffensiveItems = {
@@ -57,7 +59,8 @@ local ItemsToBuyAsMid = {StartingItems = {
 		},
 		DefensiveItems = {
 			"item_hurricane_pike",
-			"item_black_king_bar"
+			"item_black_king_bar",
+		    "item_ultimate_scepter"
 		}
 	}}
 local ItemsToBuyAsOfflane = {}

--- a/item_usage.lua
+++ b/item_usage.lua
@@ -97,7 +97,7 @@ function UseRegenItems()
         end
 
         local tango_shared = utils.HaveItem(npcBot, "item_tango_single");
-        if tango_shared ~= nil  and tango_shared:IsFullyCastable() then
+        if tango_shared ~= nil  and tango_shared:IsFullyCastable() and (not getHeroVar("IsRetreating")) then
             if (npcBot:GetMaxHealth()-npcBot:GetHealth()) > 200 and not npcBot:HasModifier("modifier_tango_heal") then
                 local tree = utils.GetNearestTree(npcBot)
                 if tree ~= nil then
@@ -108,7 +108,7 @@ function UseRegenItems()
         end
 
         local tango = utils.HaveItem(npcBot, "item_tango");
-        if tango ~= nil and tango:IsFullyCastable() then
+        if tango ~= nil and tango:IsFullyCastable() and (not getHeroVar("IsRetreating")) then
             if (npcBot:GetMaxHealth()-npcBot:GetHealth()) > 200 and not npcBot:HasModifier("modifier_tango_heal") then
                 local tree = utils.GetNearestTree(npcBot)
                 if tree ~= nil then

--- a/laning_generic.lua
+++ b/laning_generic.lua
@@ -247,6 +247,7 @@ local function CSing(npcBot)
 
 	local AllyCreeps = npcBot:GetNearbyCreeps(EyeRange,false);
 	local EnemyCreeps = npcBot:GetNearbyCreeps(EyeRange,true);
+	local EnemyTowers = npcBot:GetNearbyTowers(EyeRange,true);
 	
 	if (AllyCreeps==nil) or (#AllyCreeps==0) then
 		LaningState = LaningStates.GettingBack;
@@ -332,7 +333,7 @@ local function CSing(npcBot)
 			approachScalar = 2.5
 		end
 		
-		if (not ShouldPush) and WeakestCreepHealth < damage*approachScalar and GetUnitToUnitDistance(npcBot,WeakestCreep) > AttackRange then
+		if (not ShouldPush) and WeakestCreepHealth < damage*approachScalar and GetUnitToUnitDistance(npcBot,WeakestCreep) > AttackRange and EnemyTowers == nil then
 			local dest = utils.VectorTowards(WeakestCreep:GetLocation(),GetLocationAlongLane(CurLane,LanePos-0.03), AttackRange-20)
 			npcBot:Action_MoveToLocation(dest)
 			return

--- a/utility.lua
+++ b/utility.lua
@@ -1107,11 +1107,9 @@ function U.GetWeakestCreep(creeps)
     for _,creep in pairs(creeps) do
         U.UpdateCreepHealth(creep)
         if creep:IsAlive() then
-            if creep:GetHealth() ~= creep:GetMaxHealth() then
-                if creep:GetHealth()<LowestHealth then
-                    LowestHealth=creep:GetHealth();
-                    WeakestCreep=creep;
-                end
+            if creep:GetHealth()<LowestHealth then
+                LowestHealth=creep:GetHealth();
+                WeakestCreep=creep;
 			end
         end
     end


### PR DESCRIPTION
- drow change in jungling mechanic, will only jungle when not pushing and
when needs a little bit gold. still a WIP
- reverted changes to how weakest creep is obtained and changed the
bot's laning mechanic when near enemy tower
- modified item_usage when using tango since i noticed the bot stutter
whether to eat a tree or retreat which leads to being killed by enemy
bot, so now the bot will retreat first to safety before eating a tree